### PR TITLE
[fix]Error by type hinting  at onDebugPhpError

### DIFF
--- a/Panda.php
+++ b/Panda.php
@@ -491,7 +491,7 @@ class Panda
      *
      * @return object
      */
-    public static function onDebugPhpError($code, $message, $file, $line, array $errcontext)
+    public static function onDebugPhpError($code, $message, $file, $line, $errcontext)
     {
         $type = self::$phpError[$code];
         $simpleErrorString =  "[{$type}] {$message} in {$file} on line {$line}";


### PR DESCRIPTION
onDebugPhpErrorの引数で$errcontextがnull場合にFatal Errorが発生する