### PR TITLE
fix tempdirの取得処理を修正

### DIFF
--- a/Panda.php
+++ b/Panda.php
@@ -1281,6 +1281,10 @@ EOD;
         if ($var) {
             return $var;
         }
+        $var = sys_get_temp_dir();
+        if ($var) {
+            return $var;
+        }
         $tempfile = tempnam(uniqid(rand(), true), '');
         if (file_exists($tempfile)) {
             unlink($tempfile);


### PR DESCRIPTION
tempnamまで行ってファイルが作成できない場合にphp7にてnoticeが出てしまい、Error in Panda !となってしまうため、その前にsys_get_temp_dirで取得